### PR TITLE
Fixxed your Arch Linux Skript

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Arch Linux
 	
 	sudo pacman -S git
 
-	cd ~ && git clone https://github.com/FemBoysAreCute/Minecraft-Bedrock-Launcher-Linux-For-Free.git
+	cd ~ && git clone https://github.com/FemBoysAreCute/Minecraft-Linux-Bedrock-Launcher-For-Linux-Free.git
 
 	cd Minecraft-Bedrock-Launcher-Linux-For-Free 
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ Credits to TheSonicMaster for the modified launcher appimage, and the minecraft 
 So if you want to get Minecraft Bedrock for free on Linux. You have to download the 2 files in the releases, one for the app image and one for the mineraft version.
  Make sure you save the files to Downloads.
 
-Arch Linux (I suspect it isn't working)
+Arch Linux
 	
 	sudo pacman -S git
 
-	cd ~ && git clone https://github.com/Parindraa/Minecraft-Bedrock-Launcher-Linux-For-Free.git
+	cd ~ && git clone https://github.com/FemBoysAreCute/Minecraft-Bedrock-Launcher-Linux-For-Free.git
 
 	cd Minecraft-Bedrock-Launcher-Linux-For-Free 
 

--- a/archinstall.sh
+++ b/archinstall.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
-yes | sudo pacman -S appimagelauncher
+
+sudo pacman -S --noconfirm appimagelauncher
 
 chmod +x ~/Downloads/Minecraft.AppImage
 
+mkdir -p ~/Minecraft-Bedrock-Launcher-Linux-For-Free/
+
 cp ~/Downloads/Minecraft.AppImage ~/Minecraft-Bedrock-Launcher-Linux-For-Free/
 
-./Minecraft.AppImage
-
-
+~/Minecraft-Bedrock-Launcher-Linux-For-Free/Minecraft.AppImage


### PR DESCRIPTION
There are several issues and opportunities for improvement in your Arch Linux script:  

1. **`yes | sudo pacman -S appimagelauncher`**  
   - `yes |` is not necessary as Pacman would already request confirmation.  
   - Better would be: `sudo pacman -S --noconfirm appimagelauncher` to confirm automatically.  

2. **Set path to AppImage and execute**  
   - `./Minecraft.AppImage` only works if you are currently in the correct directory.  
   - After copying, you should either use the absolute path or go to the target directory.